### PR TITLE
shift parameter to capture remaining arguments (compatible with sh)

### DIFF
--- a/get-gitlab-settings
+++ b/get-gitlab-settings
@@ -11,7 +11,8 @@ function _kubectl() {
 }
 
 DEPLOY_USER="$1"
-kubectl_options="${@:2}"
+shift
+kubectl_options="$2"
 
 CONTEXT="$(kubectl config current-context)"
 CLUSTER="$(kubectl config view -o "jsonpath={.contexts[?(@.name==\"$CONTEXT\")].context.cluster}")"

--- a/get-gitlab-settings
+++ b/get-gitlab-settings
@@ -12,7 +12,7 @@ function _kubectl() {
 
 DEPLOY_USER="$1"
 shift
-kubectl_options="$2"
+kubectl_options="$@"
 
 CONTEXT="$(kubectl config current-context)"
 CLUSTER="$(kubectl config view -o "jsonpath={.contexts[?(@.name==\"$CONTEXT\")].context.cluster}")"


### PR DESCRIPTION
nice work on the tooling, i was faced with building this stuff myself when i stumbled upon it trying to sort out how to configure gitlab + k8s.

so in `/bin/sh`, which is the shell defined on `get-gitlab-settings`, the parameter which is being used to gather `kubectl_options` is actually returning all the parameters after the 2nd character. for example.

```
/bin # get-gitlab-settings deploy --namespace=spc-prod
+ '[' -z deploy ]
+ DEPLOY_USER=deploy
+ kubectl_options='ploy --namespace=spc-prod'
.. SNIP ..
+ _kubectl get serviceaccount deploy -o 'jsonpath={.secrets[0].name}'
+ kubectl get serviceaccount deploy -o 'jsonpath={.secrets[0].name}' ploy '--namespace=spc-prod'
Error from server (NotFound): serviceaccounts "ploy" not found
```
https://stackoverflow.com/a/9057699

I've applied a fix which should work in both `bash` and `sh`. it works, but i've run into another issue where the openssl dependencies aren't available in the image.